### PR TITLE
K8s/1.26.0

### DIFF
--- a/kontainerd/files/containerd.service
+++ b/kontainerd/files/containerd.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=containerd container runtime
+Documentation=https://containerd.io
+After=network.target local-fs.target
+
+[Service]
+ExecStartPre=-/sbin/modprobe overlay
+ExecStart=/usr/bin/containerd
+
+Type=notify
+Delegate=yes
+KillMode=process
+Restart=always
+RestartSec=5
+# Having non-zero Limit*s causes performance problems due to accounting overhead
+# in the kernel. We recommend using cgroups to do container-local accounting.
+LimitNPROC=infinity
+LimitCORE=infinity
+LimitNOFILE=infinity
+# Comment TasksMax if your systemd version does not supports it.
+# Only systemd 226 and above support this version.
+TasksMax=infinity
+OOMScoreAdjust=-999
+
+[Install]
+WantedBy=multi-user.target

--- a/kontainerd/tasks/containerd.yml
+++ b/kontainerd/tasks/containerd.yml
@@ -23,10 +23,28 @@
     state: present
   loop: "{{ kernel_parameters_list }}"
 
-- name: Install containerd 
-  apt:
-    name: containerd
-    state: present
+- name: "Download containerd {{ containerd_version }}"
+  get_url: 
+    url: "https://github.com/containerd/containerd/releases/download/v{{ containerd_version }}/containerd-{{ containerd_version }}-linux-amd64.tar.gz"
+    dest: "/tmp/containerd-{{ containerd_version }}-linux-amd64.tar.gz"
+    force: no
+
+- name: Extract and place containerd in correct location
+  unarchive:
+    src: "/tmp/containerd-{{ containerd_version }}-linux-amd64.tar.gz"
+    dest: /usr/bin
+    extra_opts: [--strip-components=1] # Ignore outer bin file containing containerd binaries
+
+- name: Place containerd service in correct location
+  copy:
+    src: containerd.service
+    dest: /lib/systemd/system/containerd.service
+
+- name: Install runc
+  get_url:
+    url: "https://github.com/opencontainers/runc/releases/download/v{{ runc_version }}/runc.amd64"
+    dest: /usr/local/sbin/runc
+    mode: '755'
 
 - name: Generate containerd default configuration file
   shell: "containerd config default"

--- a/kontainerd/tasks/containerd.yml
+++ b/kontainerd/tasks/containerd.yml
@@ -79,3 +79,8 @@
     line: SystemdCgroup = true
     state: present
   notify: restart containerd service
+
+- name: Enable containerd
+  service:
+    name: containerd
+    enabled: true

--- a/kontainerd/tasks/prerequisites.yml
+++ b/kontainerd/tasks/prerequisites.yml
@@ -37,7 +37,7 @@
     update_cache: True 
 
 - set_fact:
-    k8s_version: 1.24.0-00
+    k8s_version: 1.26.0-00
 
 - name: Install kubernetes packages 
   apt:

--- a/kontainerd/vars/main.yml
+++ b/kontainerd/vars/main.yml
@@ -23,5 +23,5 @@ k8s_dependencies:
 podman_repo: "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_{{ version_id }}/ /"
 podman_key: "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_{{ version_id }}/Release.key"
 
-containerd_version: 1.6.4
+containerd_version: 1.6.5
 runc_version: 1.1.3

--- a/kontainerd/vars/main.yml
+++ b/kontainerd/vars/main.yml
@@ -22,3 +22,6 @@ k8s_dependencies:
 
 podman_repo: "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_{{ version_id }}/ /"
 podman_key: "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_{{ version_id }}/Release.key"
+
+containerd_version: 1.6.4
+runc_version: 1.1.3


### PR DESCRIPTION
- Upgrade Kubernetes to **`V1.26`**
- Install containerd version **`1.6.5`** to [address broken weave installation](https://github.com/containerd/containerd/issues/6921) by ~~1.6.4~~ 
- Install runc version **`1.1.3`**